### PR TITLE
Extract inline styles into shared stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,69 +6,7 @@
   <title>Gattone Studios — Creative Strategy & Design</title>
   <meta name="description" content="Gattone Studios builds brand systems, automation, and high-impact visuals. Strategy-first. Outcome-driven." />
   <link rel="icon" href="favicon.ico" />
-  <style>
-    body {
-      margin: 0;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-      background: #0b0c10;
-      color: #f5f6fa;
-      line-height: 1.6;
-    }
-    header {
-      text-align: center;
-      padding: 80px 20px 60px;
-      background: linear-gradient(160deg, #0b0c10, #151822);
-    }
-    header h1 {
-      font-size: 2.8rem;
-      margin: 0 0 20px;
-    }
-    header p {
-      font-size: 1.2rem;
-      color: #aab3c5;
-      max-width: 700px;
-      margin: 0 auto;
-    }
-    nav {
-      text-align: center;
-      margin-top: 30px;
-    }
-    nav a {
-      color: #7df9ff;
-      margin: 0 15px;
-      text-decoration: none;
-      font-weight: bold;
-    }
-    section {
-      max-width: 900px;
-      margin: 60px auto;
-      padding: 0 20px;
-    }
-    h2 {
-      font-size: 1.8rem;
-      margin-bottom: 12px;
-    }
-    footer {
-      text-align: center;
-      padding: 30px 20px;
-      border-top: 1px solid #1e222f;
-      font-size: 0.9rem;
-      color: #aab3c5;
-    }
-    .btn {
-      display: inline-block;
-      margin-top: 20px;
-      padding: 12px 20px;
-      background: #7df9ff;
-      color: #0b0c10;
-      border-radius: 6px;
-      font-weight: bold;
-      text-decoration: none;
-    }
-    .btn:hover {
-      background: #5de4e6;
-    }
-  </style>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
 

--- a/privacy.html
+++ b/privacy.html
@@ -4,14 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Privacy Policy — Gattone Studios</title>
-  <style>
-    body { font-family: system-ui, sans-serif; line-height:1.6; max-width:800px; margin:40px auto; padding:0 20px; color:#222; }
-    h1 { font-size:2rem; margin-bottom:20px; }
-    h2 { margin-top:30px; font-size:1.3rem; }
-    a { color:#007bff; }
-  </style>
+  <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
+<body class="content-page">
   <h1>Privacy Policy</h1>
   <p>Effective Date: <script>document.write(new Date().getFullYear());</script></p>
 

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,87 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #0b0c10;
+  color: #f5f6fa;
+  line-height: 1.6;
+}
+
+body.content-page {
+  max-width: 800px;
+  margin: 40px auto;
+  padding: 0 20px;
+}
+
+header {
+  text-align: center;
+  padding: 80px 20px 60px;
+  background: linear-gradient(160deg, #0b0c10, #151822);
+}
+
+header h1 {
+  font-size: 2.8rem;
+  margin: 0 0 20px;
+}
+
+header p {
+  font-size: 1.2rem;
+  color: #aab3c5;
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+nav {
+  text-align: center;
+  margin-top: 30px;
+}
+
+nav a {
+  color: #7df9ff;
+  margin: 0 15px;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+section {
+  max-width: 900px;
+  margin: 60px auto;
+  padding: 0 20px;
+}
+
+h1 {
+  font-size: 2rem;
+  margin-bottom: 20px;
+}
+
+h2 {
+  font-size: 1.8rem;
+  margin-top: 30px;
+  margin-bottom: 12px;
+}
+
+a {
+  color: #7df9ff;
+}
+
+footer {
+  text-align: center;
+  padding: 30px 20px;
+  border-top: 1px solid #1e222f;
+  font-size: 0.9rem;
+  color: #aab3c5;
+}
+
+.btn {
+  display: inline-block;
+  margin-top: 20px;
+  padding: 12px 20px;
+  background: #7df9ff;
+  color: #0b0c10;
+  border-radius: 6px;
+  font-weight: bold;
+  text-decoration: none;
+}
+
+.btn:hover {
+  background: #5de4e6;
+}

--- a/terms.html
+++ b/terms.html
@@ -4,14 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Terms of Service — Gattone Studios</title>
-  <style>
-    body { font-family: system-ui, sans-serif; line-height:1.6; max-width:800px; margin:40px auto; padding:0 20px; color:#222; }
-    h1 { font-size:2rem; margin-bottom:20px; }
-    h2 { margin-top:30px; font-size:1.3rem; }
-    a { color:#007bff; }
-  </style>
+  <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
+<body class="content-page">
   <h1>Terms of Service</h1>
   <p>Effective Date: <script>document.write(new Date().getFullYear());</script></p>
 


### PR DESCRIPTION
## Summary
- consolidate common fonts, colors, and layout rules into a new `styles.css`.
- remove inline `<style>` blocks from `index.html`, `privacy.html`, and `terms.html`.
- link all pages to the external stylesheet and center standalone documents with a `content-page` body class.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/gattone-studios-site/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a4ee89ad44832990177259f6012e01
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Extracted shared styles into a single styles.css and removed inline styles to make the site consistent and easier to maintain. Privacy and Terms now use a centered content layout.

- **Refactors**
  - Added styles.css with common fonts, colors, and layout rules.
  - Removed inline style blocks from index.html, privacy.html, and terms.html.
  - Linked all pages to styles.css and applied the content-page body class for standalone documents.

<!-- End of auto-generated description by cubic. -->

