### PR TITLE
Add shared header/footer and dark theme styling to policy pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,69 +6,8 @@
   <title>Gattone Studios — Creative Strategy & Design</title>
   <meta name="description" content="Gattone Studios builds brand systems, automation, and high-impact visuals. Strategy-first. Outcome-driven." />
   <link rel="icon" href="favicon.ico" />
-  <style>
-    body {
-      margin: 0;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-      background: #0b0c10;
-      color: #f5f6fa;
-      line-height: 1.6;
-    }
-    header {
-      text-align: center;
-      padding: 80px 20px 60px;
-      background: linear-gradient(160deg, #0b0c10, #151822);
-    }
-    header h1 {
-      font-size: 2.8rem;
-      margin: 0 0 20px;
-    }
-    header p {
-      font-size: 1.2rem;
-      color: #aab3c5;
-      max-width: 700px;
-      margin: 0 auto;
-    }
-    nav {
-      text-align: center;
-      margin-top: 30px;
-    }
-    nav a {
-      color: #7df9ff;
-      margin: 0 15px;
-      text-decoration: none;
-      font-weight: bold;
-    }
-    section {
-      max-width: 900px;
-      margin: 60px auto;
-      padding: 0 20px;
-    }
-    h2 {
-      font-size: 1.8rem;
-      margin-bottom: 12px;
-    }
-    footer {
-      text-align: center;
-      padding: 30px 20px;
-      border-top: 1px solid #1e222f;
-      font-size: 0.9rem;
-      color: #aab3c5;
-    }
-    .btn {
-      display: inline-block;
-      margin-top: 20px;
-      padding: 12px 20px;
-      background: #7df9ff;
-      color: #0b0c10;
-      border-radius: 6px;
-      font-weight: bold;
-      text-decoration: none;
-    }
-    .btn:hover {
-      background: #5de4e6;
-    }
-  </style>
+  <link rel="stylesheet" href="styles.css">
+
 </head>
 <body>
 

--- a/privacy.html
+++ b/privacy.html
@@ -1,47 +1,66 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Privacy Policy — Gattone Studios</title>
-  <style>
-    body { font-family: system-ui, sans-serif; line-height:1.6; max-width:800px; margin:40px auto; padding:0 20px; color:#222; }
-    h1 { font-size:2rem; margin-bottom:20px; }
-    h2 { margin-top:30px; font-size:1.3rem; }
-    a { color:#007bff; }
-  </style>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <h1>Privacy Policy</h1>
-  <p>Effective Date: <script>document.write(new Date().getFullYear());</script></p>
+  <header>
+    <h1>Gattone Studios</h1>
+    <p>Creative systems, brand strategy, and design that work in the real world.
+       Strategy-led, outcome-driven, and built for clarity and scale.</p>
+    <nav>
+      <a href="index.html#services">Services</a>
+      <a href="index.html#work">Work</a>
+      <a href="index.html#about">About</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="terms.html">Terms</a>
+    </nav>
+    <a href="index.html#contact" class="btn">Start a Project</a>
+  </header>
 
-  <p>Gattone Studios values your privacy. This Privacy Policy explains how we handle personal information when you use our website or services.</p>
+  <main>
+    <h1>Privacy Policy</h1>
+    <p>Effective Date: <script>document.write(new Date().getFullYear());</script></p>
 
-  <h2>Information We Collect</h2>
-  <p>We may collect:</p>
-  <ul>
-    <li>Contact details you provide (such as name and email).</li>
-    <li>Project information you submit through forms.</li>
-    <li>Basic technical data (browser type, device, approximate location) via analytics tools.</li>
-  </ul>
+    <p>Gattone Studios values your privacy. This Privacy Policy explains how we handle personal information when you use our website or services.</p>
 
-  <h2>How We Use Information</h2>
-  <p>We use collected information to:</p>
-  <ul>
-    <li>Communicate with you about services.</li>
-    <li>Deliver and improve our offerings.</li>
-    <li>Maintain site security and functionality.</li>
-  </ul>
+    <h2>Information We Collect</h2>
+    <p>We may collect:</p>
+    <ul>
+      <li>Contact details you provide (such as name and email).</li>
+      <li>Project information you submit through forms.</li>
+      <li>Basic technical data (browser type, device, approximate location) via analytics tools.</li>
+    </ul>
 
-  <h2>Sharing</h2>
-  <p>We do not sell your data. Information may be shared only with trusted service providers (e.g. hosting, email) for operational purposes.</p>
+    <h2>How We Use Information</h2>
+    <p>We use collected information to:</p>
+    <ul>
+      <li>Communicate with you about services.</li>
+      <li>Deliver and improve our offerings.</li>
+      <li>Maintain site security and functionality.</li>
+    </ul>
 
-  <h2>Your Rights</h2>
-  <p>You may request access, updates, or deletion of your personal data by contacting us at <a href="mailto:allisongattone@gmail.com">allisongattone@gmail.com</a>.</p>
+    <h2>Sharing</h2>
+    <p>We do not sell your data. Information may be shared only with trusted service providers (e.g. hosting, email) for operational purposes.</p>
 
-  <h2>Changes</h2>
-  <p>We may update this Privacy Policy from time to time. The latest version will always be posted here.</p>
+    <h2>Your Rights</h2>
+    <p>You may request access, updates, or deletion of your personal data by contacting us at <a href="mailto:allisongattone@gmail.com">allisongattone@gmail.com</a>.</p>
 
-  <p>Contact: <a href="mailto:allisongattone@gmail.com">allisongattone@gmail.com</a></p>
+    <h2>Changes</h2>
+    <p>We may update this Privacy Policy from time to time. The latest version will always be posted here.</p>
+
+    <p>Contact: <a href="mailto:allisongattone@gmail.com">allisongattone@gmail.com</a></p>
+  </main>
+
+  <footer>
+    © <span id="year"></span> Gattone Studios. All rights reserved.
+  </footer>
+
+  <script>
+    document.getElementById("year").textContent = new Date().getFullYear();
+  </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,80 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #0b0c10;
+  color: #f5f6fa;
+  line-height: 1.6;
+}
+
+header {
+  text-align: center;
+  padding: 80px 20px 60px;
+  background: linear-gradient(160deg, #0b0c10, #151822);
+}
+
+header h1 {
+  font-size: 2.8rem;
+  margin: 0 0 20px;
+}
+
+header p {
+  font-size: 1.2rem;
+  color: #aab3c5;
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+nav {
+  text-align: center;
+  margin-top: 30px;
+}
+
+nav a {
+  color: #7df9ff;
+  margin: 0 15px;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+main, section {
+  max-width: 900px;
+  margin: 60px auto;
+  padding: 0 20px;
+}
+
+h1 {
+  font-size: 2.2rem;
+  margin-bottom: 20px;
+}
+
+h2 {
+  font-size: 1.8rem;
+  margin-bottom: 12px;
+}
+
+footer {
+  text-align: center;
+  padding: 30px 20px;
+  border-top: 1px solid #1e222f;
+  font-size: 0.9rem;
+  color: #aab3c5;
+}
+
+.btn {
+  display: inline-block;
+  margin-top: 20px;
+  padding: 12px 20px;
+  background: #7df9ff;
+  color: #0b0c10;
+  border-radius: 6px;
+  font-weight: bold;
+  text-decoration: none;
+}
+
+.btn:hover {
+  background: #5de4e6;
+}
+
+a {
+  color: #7df9ff;
+}

--- a/terms.html
+++ b/terms.html
@@ -1,39 +1,58 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Terms of Service — Gattone Studios</title>
-  <style>
-    body { font-family: system-ui, sans-serif; line-height:1.6; max-width:800px; margin:40px auto; padding:0 20px; color:#222; }
-    h1 { font-size:2rem; margin-bottom:20px; }
-    h2 { margin-top:30px; font-size:1.3rem; }
-    a { color:#007bff; }
-  </style>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <h1>Terms of Service</h1>
-  <p>Effective Date: <script>document.write(new Date().getFullYear());</script></p>
+  <header>
+    <h1>Gattone Studios</h1>
+    <p>Creative systems, brand strategy, and design that work in the real world.
+       Strategy-led, outcome-driven, and built for clarity and scale.</p>
+    <nav>
+      <a href="index.html#services">Services</a>
+      <a href="index.html#work">Work</a>
+      <a href="index.html#about">About</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="terms.html">Terms</a>
+    </nav>
+    <a href="index.html#contact" class="btn">Start a Project</a>
+  </header>
 
-  <h2>1. Acceptance of Terms</h2>
-  <p>By accessing or using Gattone Studios’ website or services, you agree to these Terms of Service.</p>
+  <main>
+    <h1>Terms of Service</h1>
+    <p>Effective Date: <script>document.write(new Date().getFullYear());</script></p>
 
-  <h2>2. Services</h2>
-  <p>We provide creative strategy, design, and related consulting services. Scope and deliverables will be agreed upon per project.</p>
+    <h2>1. Acceptance of Terms</h2>
+    <p>By accessing or using Gattone Studios’ website or services, you agree to these Terms of Service.</p>
 
-  <h2>3. User Responsibilities</h2>
-  <p>You agree not to misuse the site or attempt unauthorized access to our systems. Any content you provide must be lawful and accurate.</p>
+    <h2>2. Services</h2>
+    <p>We provide creative strategy, design, and related consulting services. Scope and deliverables will be agreed upon per project.</p>
 
-  <h2>4. Intellectual Property</h2>
-  <p>All content on this site is the property of Gattone Studios unless otherwise noted. You may not reproduce, distribute, or create derivative works without permission.</p>
+    <h2>3. User Responsibilities</h2>
+    <p>You agree not to misuse the site or attempt unauthorized access to our systems. Any content you provide must be lawful and accurate.</p>
 
-  <h2>5. Limitation of Liability</h2>
-  <p>Gattone Studios is not liable for indirect or incidental damages resulting from use of the website or services.</p>
+    <h2>4. Intellectual Property</h2>
+    <p>All content on this site is the property of Gattone Studios unless otherwise noted. You may not reproduce, distribute, or create derivative works without permission.</p>
 
-  <h2>6. Changes</h2>
-  <p>We may update these Terms from time to time. Continued use constitutes acceptance of updated terms.</p>
+    <h2>5. Limitation of Liability</h2>
+    <p>Gattone Studios is not liable for indirect or incidental damages resulting from use of the website or services.</p>
 
-  <h2>7. Contact</h2>
-  <p>For questions, email: <a href="mailto:allisongattone@gmail.com">allisongattone@gmail.com</a></p>
+    <h2>6. Changes</h2>
+    <p>We may update these Terms from time to time. Continued use constitutes acceptance of updated terms.</p>
+
+    <h2>7. Contact</h2>
+    <p>For questions, email: <a href="mailto:allisongattone@gmail.com">allisongattone@gmail.com</a></p>
+  </main>
+
+  <footer>
+    © <span id="year"></span> Gattone Studios. All rights reserved.
+  </footer>
+
+  <script>
+    document.getElementById("year").textContent = new Date().getFullYear();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Extract global styles into `styles.css` and link from all pages for a consistent dark theme and responsive layout.
- Add shared navigation header and year-aware footer to Privacy and Terms pages with links to existing sections.

## Testing
- `python - <<'PY' ...` (checked that all internal links point to existing files)

------
https://chatgpt.com/codex/tasks/task_e_68a4eee5c2488329a2c9263971424f39