### PR TITLE
feat: add responsive nav for small screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -85,3 +85,10 @@ footer {
 .btn:hover {
   background: #5de4e6;
 }
+
+@media (max-width: 600px) {
+  nav a {
+    display: block;
+    margin: 10px 0;
+  }
+}


### PR DESCRIPTION
## Summary
- stack navigation links vertically on viewports narrower than 600px

## Testing
- `python3 -m http.server 8000`
- `curl -I http://localhost:8000/index.html`
- `npx playwright --help` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68b34a05d4f883298edbf2820c79a742
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make the nav responsive on small screens by stacking links vertically below 600px. Improves readability and tap targets on mobile.

<!-- End of auto-generated description by cubic. -->

