### PR TITLE
Move footer year script to external file

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Gattone Studios builds brand systems, automation, and high-impact visuals. Strategy-first. Outcome-driven." />
   <link rel="icon" href="favicon.ico" />
   <link rel="stylesheet" href="styles.css" />
+  <script src="scripts.js" defer></script>
 </head>
 <body>
 
@@ -53,8 +54,5 @@
     © <span id="year"></span> Gattone Studios. All rights reserved.
   </footer>
 
-  <script>
-    document.getElementById("year").textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,0 +1,1 @@
+document.getElementById("year").textContent = new Date().getFullYear();

--- a/scripts.js
+++ b/scripts.js
@@ -1,1 +1,1 @@
-document.getElementById("year").textContent = new Date().getFullYear();
+document.getElementById("year")?.textContent = new Date().getFullYear();


### PR DESCRIPTION
## Summary
- Add `scripts.js` to populate the footer year dynamically
- Reference `scripts.js` from `index.html` and remove inline script

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b35016d40c83299eb864d499d613d2
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Move the footer year logic from an inline script to an external scripts.js and load it with defer in index.html. This keeps the HTML clean and preserves the dynamic year without blocking rendering.

<!-- End of auto-generated description by cubic. -->

