### PR TITLE
Add canonical link tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Gattone Studios builds brand systems, automation, and high-impact visuals. Strategy-first. Outcome-driven." />
   <link rel="icon" href="favicon.ico" />
   <link rel="stylesheet" href="styles.css" />
+  <link rel="canonical" href="https://gattone-studios.com/" />
   <script src="scripts.js" defer></script>
 </head>
 <body>

--- a/privacy.html
+++ b/privacy.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Privacy Policy — Gattone Studios</title>
   <link rel="stylesheet" href="styles.css" />
+  <link rel="canonical" href="https://gattone-studios.com/privacy" />
 </head>
 <body class="content-page">
   <h1>Privacy Policy</h1>

--- a/terms.html
+++ b/terms.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Terms of Service — Gattone Studios</title>
   <link rel="stylesheet" href="styles.css" />
+  <link rel="canonical" href="https://gattone-studios.com/terms" />
 </head>
 <body class="content-page">
   <h1>Terms of Service</h1>


### PR DESCRIPTION
## Summary
- add canonical links to index.html, privacy.html, and terms.html

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b35153098c83298c5a6cebc21ac107
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added canonical link tags to index.html, privacy.html, and terms.html to set the preferred URLs and improve SEO. This helps prevent duplicate content signals from URL variants.

<!-- End of auto-generated description by cubic. -->

